### PR TITLE
build: Restructure lhci config, ignore some rules for storage pages

### DIFF
--- a/lighthouserc.yml
+++ b/lighthouserc.yml
@@ -42,3 +42,4 @@ ci:
         assertions:
           unused-javascript: 'off'
           cumulative-layout-shift: 'off'
+          max-potential-fid: 'off'

--- a/lighthouserc.yml
+++ b/lighthouserc.yml
@@ -11,27 +11,33 @@ ci:
     target: 'temporary-public-storage'
   assert:
     preset: 'lighthouse:recommended'
-    assertions:
-      first-contentful-paint:
-        - error
-        - maxNumericValue: 2000
-          aggregationMethod: optimistic
-      interactive:
-        - error
-        - maxNumericValue: 5000
-          aggregationMethod: optimistic
-      bf-cache: 'off'
-      csp-xss: 'off'
-      identical-links-same-purpose: 'off'
-      total-byte-weight: 'off'
-      color-contrast: 'off'
-      heading-order: 'off'
-      mainthread-work-breakdown: 'off'
-      bootup-time: 'off'
-      largest-contentful-paint: 'off'
-      dom-size: 'off'
-      render-blocking-resources: 'off'
-      server-response-time: 'off'
-      uses-responsive-images: 'off'
-      maskable-icon: 'off'
-      installable-manifest: 'off'
+    assertMatrix:
+      - matchingUrlPattern: ".*"
+        assertions:
+          first-contentful-paint:
+            - error
+            - maxNumericValue: 2000
+              aggregationMethod: optimistic
+          interactive:
+            - error
+            - maxNumericValue: 5000
+              aggregationMethod: optimistic
+          bf-cache: 'off'
+          csp-xss: 'off'
+          identical-links-same-purpose: 'off'
+          total-byte-weight: 'off'
+          color-contrast: 'off'
+          heading-order: 'off'
+          mainthread-work-breakdown: 'off'
+          bootup-time: 'off'
+          largest-contentful-paint: 'off'
+          dom-size: 'off'
+          render-blocking-resources: 'off'
+          server-response-time: 'off'
+          uses-responsive-images: 'off'
+          maskable-icon: 'off'
+          installable-manifest: 'off'
+      - matchingUrlPattern: "http://[^/]+/storage.*"
+        assertions:
+          unused-javascript: 'off'
+          cumulative-layout-shift: 'off'

--- a/lighthouserc.yml
+++ b/lighthouserc.yml
@@ -10,9 +10,9 @@ ci:
   upload:
     target: 'temporary-public-storage'
   assert:
-    preset: 'lighthouse:recommended'
     assertMatrix:
       - matchingUrlPattern: ".*"
+        preset: 'lighthouse:recommended'
         assertions:
           first-contentful-paint:
             - error
@@ -38,6 +38,7 @@ ci:
           maskable-icon: 'off'
           installable-manifest: 'off'
       - matchingUrlPattern: "http://[^/]+/storage.*"
+        preset: 'lighthouse:recommended'
         assertions:
           unused-javascript: 'off'
           cumulative-layout-shift: 'off'


### PR DESCRIPTION
Edited the LHCI config to use [`assertMatrix`](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md#assertmatrix) so we can customize what rules are enabled/disabled for each page. Why disable rules for all pages when you can disable them for the problematic pages only?