### PR TITLE
docs: Follow community standards

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+`hackerspace-styret@idi.ntnu.no`, or you may contact our Trusted Representative directly (updated contact information shall always be available at our [website](https://www.hackerspace-ntnu.no/about)).
+Please remember that our Trusted Representative has a duty of confidentiality - they should be contacted if you'd like to stay anonymous,
+or if you prefer not to contact the Hackerspace NTNU leadership directly.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ First, install dependencies:
 bun install
 ```
 
+Also, setup environment variables by copying the `.env.example` file to `.env` and fill in the values. `.env` files are used to store sensitive information like API keys and database credentials and it will not be committed to the repository.
+
 Then, run the development server:
 
 ```bash
@@ -31,8 +33,6 @@ You can build the project with the following command:
 ```bash
 bun run build
 ```
-
-Then setup environment variables by copying the `.env.example` file to `.env` and fill in the values. `.env` files are used to store sensitive information like API keys and database credentials and it will not be committed to the repository.
 
 To serve the build locally, run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,13 @@ Here is a list of documentations that will help you contribute to the project:
 - [Docker Compose](https://docs.docker.com/compose/) - Tool for running multi-container applications
 - [nginx](https://nginx.org/en/docs/) - Reverse proxy for routing requests to the correct service
 
+### VS Code extensions
+
+- [Auto Rename Tag](https://marketplace.visualstudio.com/items?itemName=formulahendry.auto-rename-tag)
+- [Biome](https://marketplace.visualstudio.com/items?itemName=biomejs.biome)
+- [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)
+- [Pretty TypeScript Errors](https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors)
+
 ### Other
 
 - [Mozilla](https://developer.mozilla.org/en-US/) - Great resource for looking up documentation for web technologies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing
+
+## Getting Started
+
+### Development setup
+
+Make sure you have Bun installed on your machine. If you don't have it, you can download it [here](https://bun.sh/docs/installation).
+
+If you can't install Bun, you can always use [Node.js](https://nodejs.org/en/) with the `npm` command instead, but it will not be as fast as Bun.
+
+First, install dependencies:
+
+```bash
+bun install
+```
+
+Then, run the development server:
+
+```bash
+bun dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+### Build
+
+When you build the project, you pre-render all the Server Side Generated (SSG) pages. This makes the site load faster and perform better and behave like it will when it is deployed. When serving the built project it will not hot reload when you make changes to the code like it does in development mode.
+
+You can build the project with the following command:
+
+```bash
+bun run build
+```
+
+Then setup environment variables by copying the `.env.example` file to `.env` and fill in the values. `.env` files are used to store sensitive information like API keys and database credentials and it will not be committed to the repository.
+
+To serve the build locally, run:
+
+```bash
+bun run start
+```
+
+### Check linting and formatting
+
+To check linting and formatting you run the respective command:
+
+```bash
+bun lint
+```
+
+If you are using vscode and are experiencing issues with types, you can restart the typescript server by pressing `cmd + shift + p` and then type `TypeScript: Restart TS Server` (You need to have a typescript file open for this to work).
+
+You can also try restarting the whole editor by pressing `cmd + shift + p` and then type `Developer: Reload Window`.
+
+On windows you can use `ctrl` instead of `cmd`.
+
+## Commit messages
+
+We are using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for our commit messages. This is to ensure that we have a consistent way of writing commit messages to make it easier to understand what has been changed and why. Try to follow the guidelines as closely as possible. You can also use [the recommended vscode extension](.vscode/extensions.json) to help you write the commit messages.
+
+## Code quality
+
+- To keep the code as consistent as possible use functions for react components or hooks instead of const variables with arrow function syntax. An exception is when using the forwardRef hook or when creating compound components.
+- Only use default export for pages or layouts etc. since it is required by Next.js. For everything else use named exports. This is to make it easier to find the components in the codebase or change them without ending up with different names for the same component.
+- Use `type` instead of `interface` for typescript types. This is to keep the code consistent and to make it easier to read. Also `type` is more flexible than `interface` since it can be used for unions and intersections.
+
+### Naming conventions
+
+- All layout components should end with Layout. For example: `DefaultLayout`.
+- All page components should end with Page to make it clear it is a whole page. For example: `AboutPage`.
+
+## Useful resources
+
+Here is a list of documentations that will help you contribute to the project:
+
+### Front-end
+
+- [React](https://react.dev/reference/react) - Library for building user interfaces
+- [Next.js](https://nextjs.org/docs) - Framework for routing and server-side rendering
+- [Next-intl](https://next-intl-docs.vercel.app/) - Internationalization library
+- [nuqs](https://nuqs.47ng.com/docs/installation) - Easy to use query params
+- [BlockNote](https://www.blocknotejs.org/docs) - Tool for markdown textboxes
+- [React Hook Form](https://react-hook-form.com/get-started) - When we need to handle form validation
+- [Tanstack Query](https://tanstack.com/query/latest/docs/framework/react/overview) - TRPC wraps Tanstack Query which is how we fetch data from the backend
+
+#### Styling
+
+- [Tailwind CSS](https://tailwindcss.com/docs) - Styling library
+  - [Fluid for Tailwind](https://fluid.tw/#basic-usage) - Fluid scale utility breakpoints
+  - [tailwindcss-animate](https://github.com/jamiebuilds/tailwindcss-animate) - Animation utility classes
+  - [tailwind-scrollbar](https://github.com/adoxography/tailwind-scrollbar) - Customize scrollbar with tailwind
+- [Class Variance Authority](https://beta.cva.style/) - Tool for creating style variants in our UI components
+- [shadcn/ui](https://ui.shadcn.com/docs) - Reusable UI components
+  - [Radix UI Primitives](https://www.radix-ui.com/primitives/docs/overview/introduction) - Primitives library that shadcn/ui is built on, great documentation if you need to access the underlying components
+- [Aceternity/ui](https://ui.aceternity.com/components) - More fancy components that can be used (matches shadcn/ui)
+- [tsparticles](https://github.com/tsparticles/react) - Cool particles library we can use as backgrounds
+- [Lucide](https://lucide.dev/icons/) - Icons library
+
+### Back-end
+
+- [TRPC](https://trpc.io/docs) - Tool for creating API endpoints as functions
+- [Lucia](https://lucia-auth.com) - Authentication library
+- [Drizzle](https://orm.drizzle.team/docs/overview) - ORM for interacting with the database (Postgres under the hood)
+- [s3-client](https://github.com/aws/aws-sdk-js-v3/tree/main/clients/client-s3) - AWS S3 client for uploading files
+
+### Infrastructure
+
+- [Docker](https://docs.docker.com/get-started/) - Containerization tool for the application, database and storage
+- [Colima](https://github.com/abiosoft/colima) - Container runtime for docker, I recommend this over Docker Desktop because of performance and license
+- [Docker Compose](https://docs.docker.com/compose/) - Tool for running multi-container applications
+- [nginx](https://nginx.org/en/docs/) - Reverse proxy for routing requests to the correct service
+
+### Other
+
+- [Mozilla](https://developer.mozilla.org/en-US/) - Great resource for looking up documentation for web technologies
+- [Can I use](https://caniuse.com/) - Check browser support for different web technologies (especially useful for CSS)
+
+## Icons
+
+- When using custom icons that are not provided by lucide, make sure to add them as SVGs to the `components/assets/icons` folder. This improves performance since the icons are handled as vectors and not as images.
+
+## Quirks to keep in mind
+
+- When you want to link to a new internal page use the `<Link>` component from `@/lib/navigation` instead of the normal anchortag `<a>`. This will ensure that the page is loaded with the correct locale. If you want to link to external resources or other media, use the built-in `<Link>` component from Next.js. Remember to add `prefetch={false}` to the `<Link>` component if the page is not visited often.
+  - If you need to use both `<Link>` components from `@/lib/navigation` and Next.js, make sure to import the Next.js `<Link>` component as `ExternalLink` to avoid naming conflicts.
+- Remember to surround Links with the `Button` UI component. This will provide some basic styling and accessibility features for keyboard navigation even if it is not supposed to look like a button.
+- For internationalization use the `useTranslations` hook from `next-intl`. For client components you can pass the translations as props.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Hackerspace NTNU, the DevOps Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,123 +1,15 @@
-## Getting Started
+# Hackerspace NTNU Website
 
-Here is a list of documentation to help you get started:
+The overhauled website for the [Hackerspace NTNU](https://www.hackerspace-ntnu.no/) student organization.
 
-### Frontend
+## Did you encouter an issue with the website?
 
-- [React](https://react.dev/reference/react) - Library for building user interfaces
-- [Next.js](https://nextjs.org/docs) - Framework for routing and server-side rendering
-- [Next-intl](https://next-intl-docs.vercel.app/) - Internationalization library
-- [nuqs](https://nuqs.47ng.com/docs/installation) - Easy to use query params
-- [BlockNote](https://www.blocknotejs.org/docs) - Tool for markdown textboxes
-- [React Hook Form](https://react-hook-form.com/get-started) - When we need to handle form validation
-- [Tanstack Query](https://tanstack.com/query/latest/docs/framework/react/overview) - TRPC wraps Tanstack Query which is how we fetch data from the backend
+Please report it as an [issue](https://github.com/hackerspace-ntnu/website-next/issues)!
 
-#### Styling
+If the issue needs to be resolved as soon as possible, please contact a Hackerspace NTNU member.
 
-- [Tailwind CSS](https://tailwindcss.com/docs) - Styling library
-  - [Fluid for Tailwind](https://fluid.tw/#basic-usage) - Fluid scale utility breakpoints
-  - [tailwindcss-animate](https://github.com/jamiebuilds/tailwindcss-animate) - Animation utility classes
-  - [tailwind-scrollbar](https://github.com/adoxography/tailwind-scrollbar) - Customize scrollbar with tailwind
-- [Class Variance Authority](https://beta.cva.style/) - Tool for creating style variants in our UI components
-- [shadcn/ui](https://ui.shadcn.com/docs) - Reusable UI components
-  - [Radix UI Primitives](https://www.radix-ui.com/primitives/docs/overview/introduction) - Primitives library that shadcn/ui is built on, great documentation if you need to access the underlying components
-- [Aceternity/ui](https://ui.aceternity.com/components) - More fancy components that can be used (matches shadcn/ui)
-- [tsparticles](https://github.com/tsparticles/react) - Cool particles library we can use as backgrounds
-- [Lucide](https://lucide.dev/icons/) - Icons library
+## Contributing to the project
 
-### Backend
+Thank you for dedicating your time and effort to add new features and improve the website!
 
-- [TRPC](https://trpc.io/docs) - Tool for creating API endpoints as functions
-- [Lucia](https://lucia-auth.com) - Authentication library
-- [Drizzle](https://orm.drizzle.team/docs/overview) - ORM for interacting with the database (Postgres under the hood)
-- [s3-client](https://github.com/aws/aws-sdk-js-v3/tree/main/clients/client-s3) - AWS S3 client for uploading files
-
-### Infrastructure
-
-- [Docker](https://docs.docker.com/get-started/) - Containerization tool for the application, database and storage
-- [Colima](https://github.com/abiosoft/colima) - Container runtime for docker, I recommend this over Docker Desktop because of performance and license
-- [Docker Compose](https://docs.docker.com/compose/) - Tool for running multi-container applications
-- [nginx](https://nginx.org/en/docs/) - Reverse proxy for routing requests to the correct service
-
-### Other resources
-
-- [Mozilla](https://developer.mozilla.org/en-US/) - Great resource for looking up documentation for web technologies
-- [Can I use](https://caniuse.com/) - Check browser support for different web technologies (especially useful for CSS)
-
-## Icons
-
-- When using custom icons that are not provided by lucide, make sure to add them as SVGs to the `components/assets/icons` folder. This improves performance since the icons are handled as vectors and not as images.
-
-## Quirks to keep in mind
-
-- When you want to link to a new internal page use the `<Link>` component from `@/lib/navigation` instead of the normal anchortag `<a>`. This will ensure that the page is loaded with the correct locale. If you want to link to external resources or other media, use the built-in `<Link>` component from Next.js. Remember to add `prefetch={false}` to the `<Link>` component if the page is not visited often.
-  - If you need to use both `<Link>` components from `@/lib/navigation` and Next.js, make sure to import the Next.js `<Link>` component as `ExternalLink` to avoid naming conflicts.
-- Remember to surround Links with the `Button` UI component. This will provide some basic styling and accessibility features for keyboard navigation even if it is not supposed to look like a button.
-- For internationalization use the `useTranslations` hook from `next-intl`. For client components you can pass the translations as props.
-
-## Development setup
-
-Make sure you have Bun installed on your machine. If you don't have it, you can download it [here](https://bun.sh/docs/installation).
-
-If you can't install Bun, you can always use [Node.js](https://nodejs.org/en/) with the `npm` command instead, but it will not be as fast as Bun.
-
-First, install dependencies:
-
-```bash
-bun install
-```
-
-Then, run the development server:
-
-```bash
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-## Build
-
-When you build the project, you pre-render all the Server Side Generated (SSG) pages. This makes the site load faster and perform better and behave like it will when it is deployed. When serving the built project it will not hot reload when you make changes to the code like it does in development mode.
-
-You can build the project with the following command:
-
-```bash
-bun run build
-```
-
-Then setup environment variables by copying the `.env.example` file to `.env` and fill in the values. `.env` files are used to store sensitive information like API keys and database credentials and it will not be committed to the repository.
-
-To serve the build locally, run:
-
-```bash
-bun run start
-```
-
-## Check linting and formatting
-
-To check linting and formatting you run the respective command:
-
-```bash
-bun lint
-```
-
-If you are using vscode and are experiencing issues with types, you can restart the typescript server by pressing `cmd + shift + p` and then type `TypeScript: Restart TS Server` (You need to have a typescript file open for this to work).
-
-You can also try restarting the whole editor by pressing `cmd + shift + p` and then type `Developer: Reload Window`.
-
-On windows you can use `ctrl` instead of `cmd`.
-
-## Commit messages
-
-We are using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for our commit messages. This is to ensure that we have a consistent way of writing commit messages to make it easier to understand what has been changed and why. Try to follow the guidelines as closely as possible. You can also use [the recommended vscode extension](.vscode/extensions.json) to help you write the commit messages.
-
-## Code quality
-
-- To keep the code as consistent as possible use functions for react components or hooks instead of const variables with arrow function syntax. An exception is when using the forwardRef hook or when creating compound components.
-- Only use default export for pages or layouts etc. since it is required by Next.js. For everything else use named exports. This is to make it easier to find the components in the codebase or change them without ending up with different names for the same component.
-- Use `type` instead of `interface` for typescript types. This is to keep the code consistent and to make it easier to read. Also `type` is more flexible than `interface` since it can be used for unions and intersections.
-
-### Naming conventions
-
-- All layout components should end with Layout. For example: `DefaultLayout`.
-- All page components should end with Page to make it clear it is a whole page. For example: `AboutPage`.
+For more information about our tech stack, code style, and so on, please see the [Contributing guidelines](./CONTRIBUTING.md).


### PR DESCRIPTION
This PR's goal is to follow GitHub's community standards by implementing some docs we're missing.

- MIT License
- Contribution guidelines, previously stored in README, have been moved to CONTRIBUTING
  - Slightly rewritten and restructured some places
  - Recommended VS Code extensions added
- The README is modified to have some basic info, and more may be added as needed
- A code of conduct has been added

Closes #61 

**Important**: The default code of conduct **has been modified**. Please review the original, and the adjusted version for Hackerspace. This only applies to the "Enforcement" section.

Original:
> Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.

Adjusted:
>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at `hackerspace-styret@idi.ntnu.no`, or you may contact our Trusted Representative directly (updated contact information shall always be available at our [website](https://www.hackerspace-ntnu.no/about)).
> Please remember that our Trusted Representative has a duty of confidentiality - they should be contacted if you'd like to stay anonymous, or if you prefer not to contact the Hackerspace NTNU leadership directly.
> All complaints will be reviewed and investigated promptly and fairly.
