### PR TITLE
fix: hide internal group members

### DIFF
--- a/src/server/api/routers/users.ts
+++ b/src/server/api/routers/users.ts
@@ -193,9 +193,7 @@ const usersRouter = createRouter({
         };
       });
 
-      return allMembers.filter((member) => {
-        return member.usersGroups.length > 0;
-      });
+      return allMembers.filter((member) => member.usersGroups.length > 0);
     }),
   searchMembers: protectedProcedure
     .input((input) =>


### PR DESCRIPTION
Hides members who are only part of internal groups from users without permission to view internal groups.