### PR TITLE
fix: Hide browser default input for image uploads

### DIFF
--- a/src/components/events/EditEventForm.tsx
+++ b/src/components/events/EditEventForm.tsx
@@ -151,7 +151,7 @@ function EditEventForm({
           <div className='group relative h-64 w-64 rounded-lg'>
             <field.BaseField label={t('image.label')}>
               <Input
-                className='h-58 w-full cursor-pointer rounded-lg border-none'
+                className='h-58 w-full cursor-pointer rounded-lg border-none opacity-0'
                 type='file'
                 accept='image/jpeg,image/png'
                 onChange={async (e) => {

--- a/src/components/management/slides/SlideForm.tsx
+++ b/src/components/management/slides/SlideForm.tsx
@@ -118,7 +118,7 @@ function SlideForm({ slide }: SlideFormProps) {
           <div className='group relative h-64 w-64 rounded-lg'>
             <field.BaseField label={t('image.label')}>
               <Input
-                className='h-58 w-full cursor-pointer rounded-lg border-none'
+                className='h-58 w-full cursor-pointer rounded-lg border-none opacity-0'
                 type='file'
                 accept='image/jpeg,image/png'
                 onChange={async (e) => {

--- a/src/components/settings/ProfilePictureForm.tsx
+++ b/src/components/settings/ProfilePictureForm.tsx
@@ -66,7 +66,7 @@ function ProfilePictureForm({
                   <field.BaseField label={t('profilePicture.label')}>
                     <TooltipTrigger asChild>
                       <Input
-                        className='peer h-24 w-24 cursor-pointer rounded-full'
+                        className='peer h-24 w-24 cursor-pointer rounded-full opacity-0'
                         type='file'
                         accept='image/jpeg,image/png'
                         onChange={async (e) => {

--- a/src/components/storage/EditItemForm.tsx
+++ b/src/components/storage/EditItemForm.tsx
@@ -98,7 +98,7 @@ function EditItemForm({
           <div className='group relative h-64 w-64 rounded-lg'>
             <field.BaseField label={t('image.label')}>
               <Input
-                className='h-58 w-full cursor-pointer rounded-lg border-none'
+                className='h-58 w-full cursor-pointer rounded-lg border-none opacity-0'
                 type='file'
                 accept='image/jpeg,image/png'
                 onChange={async (e) => {


### PR DESCRIPTION
This makes it so the default text saying "Browse..." and "No file selected" will not show when a transparent picture is uploaded