### PR TITLE
feat: Make rows in recent news and events clickable

### DIFF
--- a/src/components/home/EventTable.tsx
+++ b/src/components/home/EventTable.tsx
@@ -20,7 +20,7 @@ function EventTable({ events }: EventTableProps) {
                   pathname: '/events/[eventId]',
                   params: { eventId: event.id },
                 }}
-                className='block p-2'
+                className='block rounded-xl p-2 focus-visible:ring-inset'
               >
                 <h3 className='truncate'>{event.localization.name}</h3>
                 <p className='truncate'>{event.localization.summary}</p>

--- a/src/components/home/NewsTable.tsx
+++ b/src/components/home/NewsTable.tsx
@@ -20,7 +20,7 @@ function NewsTable({ articles }: NewsTableProps) {
                   pathname: '/news/[articleId]',
                   params: { articleId: article.id },
                 }}
-                className='block p-2'
+                className='block rounded-xl p-2 focus-visible:ring-inset'
               >
                 <h3 className='truncate'>{article.localization.title}</h3>
                 <p className='truncate'>{article.localization.preamble}</p>


### PR DESCRIPTION
To easily find the latest news and events, the rows are now links which users can click to easily open said news article or event.