### PR TITLE
fix: Reset page search param if modifying search query

### DIFF
--- a/src/app/[locale]/(default)/management/users/page.tsx
+++ b/src/app/[locale]/(default)/management/users/page.tsx
@@ -80,7 +80,7 @@ export default async function UsersManagementPage({
         <h1 className='text-center'>{t('title')}</h1>
         <MembersSearchBar
           placeholder={t('searchUser')}
-          t={{ name: tUi('name') }}
+          t={{ name: tUi('name'), page: tUi('page') }}
           className='w-full'
         />
         <UserSearchTable users={users} />

--- a/src/app/[locale]/(default)/members/(main)/layout.tsx
+++ b/src/app/[locale]/(default)/members/(main)/layout.tsx
@@ -23,7 +23,7 @@ export default async function MembersLayout({
       <div className='my-4 flex flex-col justify-center gap-2 lg:flex-row'>
         <MembersSearchBar
           placeholder={t('searchPlaceholder')}
-          t={{ name: tUi('name') }}
+          t={{ name: tUi('name'), page: tUi('page') }}
         />
       </div>
       {children}

--- a/src/app/[locale]/(default)/storage/(main)/layout.tsx
+++ b/src/app/[locale]/(default)/storage/(main)/layout.tsx
@@ -86,7 +86,7 @@ export default async function StorageLayout({
       <div className='my-4 flex flex-col justify-center gap-2 lg:flex-row'>
         <StorageSearchBar
           placeholder={t('searchPlaceholder')}
-          t={{ name: t('searchParams.name') }}
+          t={{ name: t('searchParams.name'), page: tUi('page') }}
         />
         <Suspense fallback={<SelectorsSkeleton />}>
           <SortSelector

--- a/src/components/members/MembersSearchBar.tsx
+++ b/src/components/members/MembersSearchBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 import { SearchBar } from '@/components/composites/SearchBar';
 import { useDebounceCallback } from '@/lib/hooks/useDebounceCallback';
 import { cx } from '@/lib/utils';
@@ -13,6 +13,7 @@ function MembersSearchBar({
   placeholder: string;
   t: {
     name: string;
+    page: string;
   };
   className?: string;
 }) {
@@ -22,15 +23,26 @@ function MembersSearchBar({
       .withDefault('')
       .withOptions({ shallow: false, clearOnDefault: true }),
   );
+  const [, setPage] = useQueryState(
+    t.page,
+    parseAsInteger
+      .withDefault(1)
+      .withOptions({ shallow: false, clearOnDefault: true }),
+  );
 
-  const debouncedSetSearch = useDebounceCallback(setSearch, 500);
+  function handleChange(value: string) {
+    setSearch(value);
+    setPage(1);
+  }
+
+  const debouncedHandleChange = useDebounceCallback(handleChange, 500);
 
   return (
     <SearchBar
       className={cx('lg:max-w-2xl', className)}
       placeholder={placeholder}
       defaultValue={search}
-      onChange={(e) => debouncedSetSearch(e.target.value)}
+      onChange={(e) => debouncedHandleChange(e.target.value)}
     />
   );
 }

--- a/src/components/storage/StorageSearchBar.tsx
+++ b/src/components/storage/StorageSearchBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { parseAsString, useQueryState } from 'nuqs';
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs';
 import { SearchBar } from '@/components/composites/SearchBar';
 import { useDebounceCallback } from '@/lib/hooks/useDebounceCallback';
 
@@ -8,6 +8,7 @@ type StorageSearchBarProps = {
   placeholder: string;
   t: {
     name: string;
+    page: string;
   };
 };
 
@@ -18,15 +19,26 @@ function StorageSearchBar({ placeholder, t }: StorageSearchBarProps) {
       .withDefault('')
       .withOptions({ shallow: false, clearOnDefault: true }),
   );
+  const [, setPage] = useQueryState(
+    t.page,
+    parseAsInteger
+      .withDefault(1)
+      .withOptions({ shallow: false, clearOnDefault: true }),
+  );
 
-  const debouncedSetSearch = useDebounceCallback(setSearch, 500);
+  function handleChange(value: string) {
+    setSearch(value);
+    setPage(1);
+  }
+
+  const debouncedHandleChange = useDebounceCallback(handleChange, 500);
 
   return (
     <SearchBar
       className='lg:max-w-2xl'
       placeholder={placeholder}
       defaultValue={search}
-      onChange={(e) => debouncedSetSearch(e.target.value)}
+      onChange={(e) => debouncedHandleChange(e.target.value)}
     />
   );
 }


### PR DESCRIPTION
If the user changes the search query after they move to another page, we need to reset the page count.

For example:
The user is on page 2. They start to search for a user named "John".
Then the `page` search param must be reset to be page 1 to show the results correctly.