### PR TITLE
fix: add min and max length to storage item category schema

### DIFF
--- a/messages/en-GB.json
+++ b/messages/en-GB.json
@@ -777,6 +777,9 @@
       "successEditMessage": "Item category edited successfully!",
       "successDeleteMessage": "Item category deleted successfully!",
       "invalidName": "Invalid category name",
+      "required": "Category name is required",
+      "maxLength": "Category name must be {count, plural, one {one character} other {# characters}} or fewer.",
+      "addNewCategory": "Add new category",
       "api": {
         "insertFailed": "Failed to add category",
         "updateFailed": "Failed to update category",

--- a/messages/nb-NO.json
+++ b/messages/nb-NO.json
@@ -777,6 +777,8 @@
       "successEditMessage": "Kategorien har blitt redigert!",
       "successDeleteMessage": "Kategorien har blitt slettet!",
       "invalidName": "Ugyldig kategorinavn",
+      "required": "Kategorinavn er påkrevd",
+      "maxLength": "Kategorinavn kan maks være {count, plural, one {ett tegn} other {# tegn}}.",
       "api": {
         "insertFailed": "Feilet å legge til kategori",
         "updateFailed": "Feilet å redigere kategori",

--- a/src/components/layout/Banner.tsx
+++ b/src/components/layout/Banner.tsx
@@ -37,6 +37,7 @@ function Banner() {
         <Carousel
           opts={{
             loop: true,
+            watchDrag: false,
             duration: 50,
           }}
           plugins={[

--- a/src/validations/storage/itemCategoryFormSchema.ts
+++ b/src/validations/storage/itemCategoryFormSchema.ts
@@ -3,8 +3,14 @@ import type { Translations } from '@/lib/locale';
 
 function itemCategoryFormSchema(t: Translations) {
   return z.object({
-    nameEnglish: z.string({ message: t('storage.categories.invalidName') }),
-    nameNorwegian: z.string({ message: t('storage.categories.invalidName') }),
+    nameEnglish: z
+      .string({ message: t('storage.categories.invalidName') })
+      .min(1, { message: t('storage.categories.required') })
+      .max(128, { message: t('storage.categories.maxLength', { count: 128 }) }),
+    nameNorwegian: z
+      .string({ message: t('storage.categories.invalidName') })
+      .min(1, { message: t('storage.categories.required') })
+      .max(128, { message: t('storage.categories.maxLength', { count: 128 }) }),
   });
 }
 


### PR DESCRIPTION
Categories can no longer be created without a translation. Also banner can't be dragged