### PR TITLE
build: upgrade nodemailer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "website-next",
@@ -95,7 +94,7 @@
         "next": "15.4.11",
         "next-intl": "^4.3.12",
         "next-themes": "1.0.0-beta.0",
-        "nodemailer": "^6.10.1",
+        "nodemailer": "^7.0.13",
         "nuqs": "^2.7.2",
         "oslo": "^1.2.1",
         "pdf-lib": "^1.17.1",
@@ -1928,7 +1927,7 @@
 
     "node-releases": ["node-releases@2.0.23", "", {}, "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg=="],
 
-    "nodemailer": ["nodemailer@6.10.1", "", {}, "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA=="],
+    "nodemailer": ["nodemailer@7.0.13", "", {}, "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "next": "15.4.11",
     "next-intl": "^4.3.12",
     "next-themes": "1.0.0-beta.0",
-    "nodemailer": "^6.10.1",
+    "nodemailer": "^7.0.13",
     "nuqs": "^2.7.2",
     "oslo": "^1.2.1",
     "pdf-lib": "^1.17.1",


### PR DESCRIPTION
Upgrades from nodemailer 6.10.1 to 7.0.13. There were no breaking changes that matter for our usage.