### PR TITLE
fix: quote card cropping by moving edit/delete buttons

### DIFF
--- a/src/app/[locale]/(default)/quotes/page.tsx
+++ b/src/app/[locale]/(default)/quotes/page.tsx
@@ -52,7 +52,7 @@ export default async function QuotesPage({
   const { user } = await api.auth.state();
 
   return (
-    <div className='container space-y-8 py-10'>
+    <div className='mx-auto max-w-4xl space-y-8 py-10'>
       <div className='relative'>
         <h1 className='text-center text-4xl tracking-tight'>{t('title')}</h1>
         {user?.groups && user.groups.length > 0 && (

--- a/src/components/quotes/QuoteCard.tsx
+++ b/src/components/quotes/QuoteCard.tsx
@@ -39,7 +39,54 @@ async function QuoteCard({
   return (
     <Card key={quote.id} className='overflow-hidden'>
       <CardHeader className='bg-muted/50 p-4'>
-        <div className='flex items-center justify-between'>
+        <div className='flex flex-col gap-2 sm:hidden'>
+          <div className='flex items-center justify-between'>
+            <div className='flex items-center gap-2'>
+              <MemberAvatar
+                user={quote.saidBy}
+                profilePictureUrl={profileImageUrl}
+              />
+              <div>
+                <p className='font-medium'>{saidByName}</p>
+              </div>
+            </div>
+            <div className='flex flex-col items-center gap-2'>
+              <Badge variant='outline'>
+                {formatter.dateTime(quote.createdAt)}
+              </Badge>
+              {quote.internal && (
+                <Badge className='justify-center rounded-full'>
+                  {tLayout('internal')}
+                </Badge>
+              )}
+            </div>
+          </div>
+          {canEdit && (
+            <div className='flex items-center gap-2 pl-14'>
+              <Link
+                href={{
+                  pathname: '/quotes/[quoteId]/edit',
+                  params: { quoteId: quote.id },
+                }}
+                variant='default'
+                size='sm-icon'
+              >
+                <EditIcon />
+              </Link>
+              <DeleteQuoteButton
+                quote={quote}
+                t={{
+                  title: t('delete.title'),
+                  description: t('delete.description'),
+                  cancel: tUi('cancel'),
+                  confirm: tUi('confirm'),
+                  success: t('delete.success'),
+                }}
+              />
+            </div>
+          )}
+        </div>
+        <div className='hidden items-center justify-between sm:flex'>
           <div className='flex items-center gap-2'>
             <MemberAvatar
               user={quote.saidBy}

--- a/src/components/quotes/QuoteCard.tsx
+++ b/src/components/quotes/QuoteCard.tsx
@@ -39,54 +39,7 @@ async function QuoteCard({
   return (
     <Card key={quote.id} className='overflow-hidden'>
       <CardHeader className='bg-muted/50 p-4'>
-        <div className='flex flex-col gap-2 sm:hidden'>
-          <div className='flex items-center justify-between'>
-            <div className='flex items-center gap-2'>
-              <MemberAvatar
-                user={quote.saidBy}
-                profilePictureUrl={profileImageUrl}
-              />
-              <div>
-                <p className='font-medium'>{saidByName}</p>
-              </div>
-            </div>
-            <div className='flex flex-col items-center gap-2'>
-              <Badge variant='outline'>
-                {formatter.dateTime(quote.createdAt)}
-              </Badge>
-              {quote.internal && (
-                <Badge className='justify-center rounded-full'>
-                  {tLayout('internal')}
-                </Badge>
-              )}
-            </div>
-          </div>
-          {canEdit && (
-            <div className='flex items-center gap-2 pl-14'>
-              <Link
-                href={{
-                  pathname: '/quotes/[quoteId]/edit',
-                  params: { quoteId: quote.id },
-                }}
-                variant='default'
-                size='sm-icon'
-              >
-                <EditIcon />
-              </Link>
-              <DeleteQuoteButton
-                quote={quote}
-                t={{
-                  title: t('delete.title'),
-                  description: t('delete.description'),
-                  cancel: tUi('cancel'),
-                  confirm: tUi('confirm'),
-                  success: t('delete.success'),
-                }}
-              />
-            </div>
-          )}
-        </div>
-        <div className='hidden items-center justify-between sm:flex'>
+        <div className='flex items-center justify-between'>
           <div className='flex items-center gap-2'>
             <MemberAvatar
               user={quote.saidBy}
@@ -96,9 +49,9 @@ async function QuoteCard({
               <p className='font-medium'>{saidByName}</p>
             </div>
           </div>
-          <div className='flex items-center gap-2'>
+          <div className='flex flex-col-reverse items-center gap-2 sm:flex-row'>
             {canEdit && (
-              <>
+              <div className='flex gap-2'>
                 <Link
                   href={{
                     pathname: '/quotes/[quoteId]/edit',
@@ -119,7 +72,7 @@ async function QuoteCard({
                     success: t('delete.success'),
                   }}
                 />
-              </>
+              </div>
             )}
             <div className='flex flex-col gap-2'>
               <Badge variant='outline'>


### PR DESCRIPTION
Fix the quote card cropping in smaller/mobile screens by moving edit/delete buttons to a new line.